### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Weixin-Mac
 
 多写两句吧，关于这个App本身的目的并不是那么的远大和雄伟，停止开发的时间也不一定什么时候就停止了。这要看腾讯自己什么时候出Mac的App，或者它什么时候考虑把这个封了。这个App本身的难度基本上说是0吧，这样放出来只是为了方便有需要的人而已，一直是开源的，您有兴趣看代码，就明白多么简单和安全。
 
-##代码分支管理
+## 代码分支管理
 
 使用的是git-flow (http://nvie.com/posts/a-successful-git-branching-model)
 
 所以最新的代码在develop上面，稳定代码在master上，发布在release上就很好理解了哈...
 
-##依赖管理
+## 依赖管理
 
 使用 [Cocoapods](https://github.com/CocoaPods/CocoaPods)进行管理，
 目前使用外部依赖有:
@@ -25,7 +25,7 @@ pod 'CocoaHTTPServer',	'~> 2.3'
 pod 'MASShortcut',      '~> 1.2.2'
 ```
 
-##开发环境需求
+## 开发环境需求
 
 我的开发环境是
 
@@ -43,7 +43,7 @@ Cocoapods 0.24.0
 4. `pods install`
 5. `open Weixin.xcworkspace`
 
-##感谢
+## 感谢
 
 我虽然增加了捐赠按钮，但本身目的不是为了通过这个进行盈利的，妄下定论的小伙伴们，还是点击下看看，当故事看也好。最后，感谢捐赠的各位。
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
